### PR TITLE
Fix unknown type of variable

### DIFF
--- a/ALS/Source/ALS/Private/Notify/AlsAnimNotify_FootstepEffects.cpp
+++ b/ALS/Source/ALS/Private/Notify/AlsAnimNotify_FootstepEffects.cpp
@@ -52,7 +52,7 @@ void UAlsAnimNotify_FootstepEffects::Notify(USkeletalMeshComponent* MeshComponen
 #endif
 
 	const FAlsFootstepEffectSettings* EffectSettings{nullptr};
-	const auto SurfaceType{Hit.PhysMaterial.IsValid() ? Hit.PhysMaterial->SurfaceType : TEnumAsByte<EPhysicalSurface>(SurfaceType_Default)};
+	const EPhysicalSurface SurfaceType{Hit.PhysMaterial.IsValid() ? Hit.PhysMaterial->SurfaceType : SurfaceType_Default};
 
 	for (const auto& Effect : FootstepEffectsSettings->Effects)
 	{

--- a/ALS/Source/ALS/Private/Notify/AlsAnimNotify_FootstepEffects.cpp
+++ b/ALS/Source/ALS/Private/Notify/AlsAnimNotify_FootstepEffects.cpp
@@ -52,7 +52,7 @@ void UAlsAnimNotify_FootstepEffects::Notify(USkeletalMeshComponent* MeshComponen
 #endif
 
 	const FAlsFootstepEffectSettings* EffectSettings{nullptr};
-	const auto SurfaceType{Hit.PhysMaterial.IsValid() ? Hit.PhysMaterial->SurfaceType : SurfaceType_Default};
+	const auto SurfaceType{Hit.PhysMaterial.IsValid() ? Hit.PhysMaterial->SurfaceType : TEnumAsByte<EPhysicalSurface>(SurfaceType_Default)};
 
 	for (const auto& Effect : FootstepEffectsSettings->Effects)
 	{


### PR DESCRIPTION
the variable SurfaceType is either of type `TEnumAsByte<EPhysicalSurface>` or `EPhysicalSurface` so the auto type is indeterminable.
I do not know why the ms compiler does not catch this.