### PR TITLE
Custom movement mode immobility issue fixed.

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -170,14 +170,6 @@ void AAlsCharacter::Tick(const float DeltaTime)
 	Super::Tick(DeltaTime);
 }
 
-void AAlsCharacter::AddMovementInput(const FVector Direction, const float Scale, const bool bForce)
-{
-	if (LocomotionMode != EAlsLocomotionMode::None)
-	{
-		Super::AddMovementInput(Direction, Scale, bForce);
-	}
-}
-
 void AAlsCharacter::Jump()
 {
 	if (LocomotionMode == EAlsLocomotionMode::Grounded &&

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -139,8 +139,6 @@ public:
 
 	virtual void Tick(float DeltaTime) override;
 
-	virtual void AddMovementInput(FVector Direction, float Scale = 1.0f, bool bForce = false) override;
-
 	virtual void Jump() override;
 
 	virtual void OnMovementModeChanged(EMovementMode PreviousMode, uint8 PreviousCustomMode = 0) override;


### PR DESCRIPTION
В текущей реализации совместное действие AlsCharacter::OnMovementModeChanged и AlsCharacter::AddMovementInput приводит к тому, что персонаж перестает двигаться в режимах Swimming, Flying и Custom. Предлагается убрать AddMovementInput из AlsCharacter вовсе.

(cherry picked from commit 3db204e03eb3bd4992b71aa1f8a0ef25be167733)

