### PR TITLE
Create CanMantle() BlueprintNativeEvent to control dynamically and allow access in children character blueprints

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -1130,6 +1130,11 @@ void AAlsCharacter::OnJumpedNetworked()
 	AnimationInstance->Jump();
 }
 
+ bool AAlsCharacter::CanMantle_Implementation() const
+{
+	return true;
+}
+
 void AAlsCharacter::FaceRotation(const FRotator NewRotation, const float DeltaTime)
 {
 	// Left empty intentionally.

--- a/Source/ALS/Private/AlsCharacter_Actions.cpp
+++ b/Source/ALS/Private/AlsCharacter_Actions.cpp
@@ -149,6 +149,9 @@ bool AAlsCharacter::TryStartMantlingInAir()
 
 bool AAlsCharacter::IsMantlingAllowedToStart() const
 {
+	if (!CanMantle()) {
+		return false;
+	}
 	return !LocomotionAction.IsValid();
 }
 

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -449,6 +449,13 @@ private:
 
 	// Mantling
 
+protected:
+	UFUNCTION(BlueprintNativeEvent, Category = "ALS|Als Character")
+	bool CanMantle() const;
+
+private:
+	bool CanMantle_Implementation() const;
+
 public:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Als Character")
 	bool TryStartMantlingGrounded();


### PR DESCRIPTION
Inspired by our previous discussion I made an overridable function to give control to derived characters (ie my plugin that extends this plugin)