### PR TITLE
 Change ApplyDesiredStance() to a virtual function to allow for derived classes to override.

### DIFF
--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -219,7 +219,7 @@ private:
 	UFUNCTION(Server, Reliable)
 	void ServerSetDesiredStance(const FGameplayTag& NewStanceTag);
 
-	void ApplyDesiredStance();
+	virtual void ApplyDesiredStance();
 
 	// Stance
 


### PR DESCRIPTION
Change ApplyDesiredStance() to a virtual function to allow for derived classes to override (ie the new sliding locomotion action in the ALSXT plugin).