### PR TITLE
fix(linux): fix linux compilation error

### DIFF
--- a/Source/ALSEditor/ALSEditor.Build.cs
+++ b/Source/ALSEditor/ALSEditor.Build.cs
@@ -15,7 +15,7 @@ public class ALSEditor : ModuleRules
 		{
 			PrivateDependencyModuleNames.AddRange(new[]
 			{
-				"AnimGraph", "BlueprintGraph"
+				"AnimGraph", "AnimGraphRuntime", "BlueprintGraph"
 			});
 		}
 	}


### PR DESCRIPTION
Fix ALSEditor compilation on Linux as suggested in #32, confirmed on Linux 5.0.2 and 5.0.3 builds natively in Ubuntu Linux.