### PR TITLE
fix locomotion mode changed to empty when in MOVE_Custom

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -339,6 +339,14 @@ void AAlsCharacter::OnMovementModeChanged(const EMovementMode PreviousMovementMo
 		case MOVE_Falling:
 			SetLocomotionMode(AlsLocomotionModeTags::InAir);
 			break;
+			
+		case MOVE_Custom:
+			if (GetCharacterMovement()->CustomMovementMode != 0)
+			{
+				// CustomMovementMode should be handled elsewhere
+				break;
+			}
+			// else : CustomMovementMode is 0, fall into default case
 
 		default:
 			SetLocomotionMode(FGameplayTag::EmptyTag);


### PR DESCRIPTION
this could avoid potentially unnecessary locomotion mode changed event