### PR TITLE
Lerp YawAmout instead of YawAngle to avoid poping

### DIFF
--- a/Source/ALS/Private/AlsAnimationInstance.cpp
+++ b/Source/ALS/Private/AlsAnimationInstance.cpp
@@ -426,16 +426,14 @@ void UAlsAnimationInstance::RefreshLookTowardsInput()
 			DeltaYawAngle = LocomotionState.YawSpeed > 0.0f ? FMath::Abs(DeltaYawAngle) : -FMath::Abs(DeltaYawAngle);
 		}
 
-		const auto InterpolationAmount{
-			UAlsMath::ExponentialDecay(GetDeltaSeconds(), Settings->View.LookTowardsInputYawAngleInterpolationSpeed)
-		};
-
-		LookTowardsInput.YawAngle = FRotator3f::NormalizeAxis(YawAngle + DeltaYawAngle * InterpolationAmount);
+		LookTowardsInput.YawAngle = FRotator3f::NormalizeAxis(YawAngle + DeltaYawAngle);
 	}
-
+	
 	LookTowardsInput.WorldYawAngle = FRotator3f::NormalizeAxis(CharacterYawAngle + LookTowardsInput.YawAngle);
 
-	LookTowardsInput.YawAmount = LookTowardsInput.YawAngle / 360.0f + 0.5f;
+	const auto TargetYawAmount = LookTowardsInput.YawAngle / 360.0f + 0.5f;
+	LookTowardsInput.YawAmount = UAlsMath::ExponentialDecay(LookTowardsInput.YawAmount, TargetYawAmount,
+		GetDeltaSeconds(), Settings->View.LookTowardsInputYawAngleInterpolationSpeed);
 
 	LookTowardsInput.bReinitializationRequired = false;
 }


### PR DESCRIPTION
When my character climbing on the wall, "hold S and A"(climbing left down) -> "keep holding S, but switch A to D"(change direction to climbing right down).

The character's head is instantly turning 180°, because `YawAmount` changed from about "0.0f" to "1.0f in a frame.

This change fixed the issue.

And if this is accepted, better also change the name of `LookTowardsInputYawAngleInterpolationSpeed`. I can do it here later or help me if you have convenience.

### Actually there is another issue when extending ALS:
`AAlsCharacter::LocomotionState::InputYawAngle` is wrong value when climbing on the wall,
because it only consider grounding movement.

Which i solve it by moving the calculation into input callback:

```c++
void SomeInputCallBack::SetCharacterInputDirection(AAlsCharacter* Character, const FVector2D& Value /*Input Action Value*/)
{
    Character->SetInputDirection(FVector{Value.X, Value.Y, 0.f});
}

void AAlsCharacter::SetInputDirection(FVector NewInputDirection)
{
	NewInputDirection = NewInputDirection.GetSafeNormal();

	if (NewInputDirection != InputDirection)
	{
		InputDirection = NewInputDirection;

		MARK_PROPERTY_DIRTY_FROM_NAME(ThisClass, InputDirection, this)

		if (GetLocalRole() == ROLE_AutonomousProxy)
		{
			ServerSetInputDirection(NewInputDirection);
		}
	}
}

void AAlsCharacter::ServerSetInputDirection_Implementation(const FVector& NewInputDirection)
{
	SetInputDirection(NewInputDirection);
}

void AAlsCharacter::RefreshLocomotion(const float DeltaTime)
{
	// If the character has the input, update the input yaw angle.

	LocomotionState.bHasInput = InputDirection.SizeSquared() > UE_KINDA_SMALL_NUMBER;

	if (LocomotionState.bHasInput)
	{
		const auto LocalInputAngle = UE_REAL_TO_FLOAT(UAlsMath::DirectionToAngleXY(InputDirection));

		const auto RotationYaw = UE_REAL_TO_FLOAT(GetViewState().Rotation.Yaw);
		
		LocomotionState.InputYawAngle = FRotator3f::NormalizeAxis(LocalInputAngle + RotationYaw);
	}
// ...

```

the `InputYawAngle` actually also implies world space angle, in order to reduce RPC call, I changed the `InputDirection` to "local". so when you holding `W`, it will only send one RPC, and turn it into world space by add character rotation yaw when using it to calculate `LocomotionState.InputYawAngle`.
(Edit: fixed `InputDirection` lost on simulated proxy in previous implementation. nothing related to this commit though.) I can do another commit in this.