### PR TITLE
Allow changing locomotionmode from a child class , e.g. for supporting swimming controls

### DIFF
--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -159,9 +159,9 @@ public:
 public:
 	const FGameplayTag& GetLocomotionMode() const;
 
-private:
 	void SetLocomotionMode(const FGameplayTag& NewLocomotionMode);
-
+	
+private:	
 	void NotifyLocomotionModeChanged(const FGameplayTag& PreviousLocomotionMode);
 
 protected:


### PR DESCRIPTION


OnMovementModeChanged sets the locomotionmode to only air or land internally , supporting an other mode is not possible without calling this  function.