### PR TITLE
Fix: GameplayTags module dependency

### DIFF
--- a/Source/ALSExtras/ALSExtras.Build.cs
+++ b/Source/ALSExtras/ALSExtras.Build.cs
@@ -11,7 +11,7 @@ public class ALSExtras : ModuleRules
 
 		PrivateDependencyModuleNames.AddRange(new[]
 		{
-			"Core", "CoreUObject", "Engine", "EnhancedInput", "AIModule", "ALS", "ALSCamera"
+			"Core", "CoreUObject", "Engine", "EnhancedInput", "AIModule", "ALS", "ALSCamera", "GameplayTags"
 		});
 	}
 }


### PR DESCRIPTION
without this, i got:

> [9/18] Link [x64] UnrealEditor-ALSExtras-Win64-DebugGame.dll
Creating library ProjectName\Plugins\ALS-Refactored\Intermediate\Build\Win64\x64\UnrealEditor\DebugGame\ALSExtras\UnrealEditor-ALSExtras-Win64-DebugGame.suppressed.lib and object 

> ProjectName\Plugins\ALS-Refactored\Intermediate\Build\Win64\x64\UnrealEditor\DebugGame\ALSExtras\UnrealEditor-ALSExtras-Win64-DebugGame.suppressed.exp

> Module.ALSExtras.cpp.obj: Error LNK2019 : unresolved external symbol "__declspec(dllimport) public: __cdecl FNativeGameplayTag::operator struct FGameplayTag(void)const " (__imp_??BFNativeGameplayTag@@QEBA?AUFGameplayTag@@XZ) referenced in function "private: void __cdecl AAlsCharacterExample::Input_OnCrouch(void)" (?Input_OnCrouch@AAlsCharacterExample@@AEAAXXZ)

> ProjectName\Plugins\ALS-Refactored\Binaries\Win64\UnrealEditor-ALSExtras-Win64-DebugGame.dll: Error LNK1120 : 1 unresolved externals