### PR TITLE
Avoiding root motion extraction failure

### DIFF
--- a/Source/ALS/Private/RootMotionSources/AlsRootMotionSource_Mantling.cpp
+++ b/Source/ALS/Private/RootMotionSources/AlsRootMotionSource_Mantling.cpp
@@ -47,6 +47,16 @@ void FAlsRootMotionSource_Mantling::PrepareRootMotion(const float SimulationDelt
 
 	const auto* Montage{MantlingSettings->Montage.Get()};
 	const auto MontageTime{MontageStartTime + GetTime() * Montage->RateScale};
+		
+	const auto TargetAnimationLocation{UAlsUtility::ExtractLastRootTransformFromMontage(Montage).GetLocation()};
+	const auto CurrentAnimationLocation{UAlsUtility::ExtractRootTransformFromMontage(Montage, MontageTime).GetLocation()};
+
+	if (FMath::IsNearlyZero(TargetAnimationLocation.Z))
+	{
+		UE_LOG(LogRootMotion, Warning, TEXT("FAlsRootMotionSource_Mantling::PrepareRootMotion fail : %s"), *Montage->GetFName().ToString());
+		RootMotionParams.Clear();
+		return;
+	}
 
 	// Synchronize the mantling animation montage's time with the mantling root motion source's time.
 	// Delta time subtraction is necessary here, otherwise there will be a one frame lag between them.
@@ -70,9 +80,6 @@ void FAlsRootMotionSource_Mantling::PrepareRootMotion(const float SimulationDelt
 		BlendInAmount = FAlphaBlend::AlphaToBlendOption(GetTime() / MontageBlendIn.GetBlendTime(),
 		                                                MontageBlendIn.GetBlendOption(), MontageBlendIn.GetCustomCurve());
 	}
-
-	const auto TargetAnimationLocation{UAlsUtility::ExtractRootTransformFromMontage(Montage, Montage->GetPlayLength()).GetLocation()};
-	const auto CurrentAnimationLocation{UAlsUtility::ExtractRootTransformFromMontage(Montage, MontageTime).GetLocation()};
 
 	const auto InterpolationAmount{CurrentAnimationLocation.Z / TargetAnimationLocation.Z};
 

--- a/Source/ALS/Private/Utility/AlsUtility.cpp
+++ b/Source/ALS/Private/Utility/AlsUtility.cpp
@@ -102,6 +102,30 @@ FTransform UAlsUtility::ExtractRootTransformFromMontage(const UAnimMontage* Mont
 	return Sequence->ExtractRootTrackTransform(Segment->ConvertTrackPosToAnimPos(Time), nullptr);
 }
 
+FTransform UAlsUtility::ExtractLastRootTransformFromMontage(const UAnimMontage* Montage)
+{
+	// Based on UMotionWarpingUtilities::ExtractRootTransformFromAnimation().
+
+	if (!IsValid(Montage))
+	{
+		return FTransform::Identity;
+	}
+
+	const auto* Segment{Montage->SlotAnimTracks[0].AnimTrack.AnimSegments.Num() > 0 ? &Montage->SlotAnimTracks[0].AnimTrack.AnimSegments.Last() : nullptr};
+	if (Segment == nullptr)
+	{
+		return FTransform::Identity;
+	}
+
+	const auto* Sequence{Cast<UAnimSequence>(Segment->GetAnimReference())};
+	if (!IsValid(Sequence))
+	{
+		return FTransform::Identity;
+	}
+
+	return Sequence->ExtractRootTrackTransform(Segment->GetEndPos(), nullptr);
+}
+
 bool UAlsUtility::ShouldDisplayDebugForActor(const AActor* Actor, const FName& DisplayName)
 {
 	const auto* World{IsValid(Actor) ? Actor->GetWorld() : nullptr};

--- a/Source/ALS/Public/Utility/AlsUtility.h
+++ b/Source/ALS/Public/Utility/AlsUtility.h
@@ -42,6 +42,9 @@ public:
 	UFUNCTION(BlueprintPure, Category = "ALS|Utility", Meta = (ReturnDisplayName = "Transform"))
 	static FTransform ExtractRootTransformFromMontage(const UAnimMontage* Montage, float Time);
 
+	UFUNCTION(BlueprintPure, Category = "ALS|Utility", Meta = (ReturnDisplayName = "Transform"))
+	static FTransform ExtractLastRootTransformFromMontage(const UAnimMontage* Montage);
+
 	UFUNCTION(BlueprintPure, Category = "ALS|Utility",
 		Meta = (DefaultToSelf = "Actor", AutoCreateRefTerm = "DisplayName", ReturnDisplayName = "Value"))
 	static bool ShouldDisplayDebugForActor(const AActor* Actor, const FName& DisplayName);


### PR DESCRIPTION
When using the method `ExtractRootTransformFromMontage(Montage, Montage->GetPlayLength())`, there were cases where the Mantle process did not work correctly because `Montage->SlotAnimTracks[0].AnimTrack.GetSegmentAtTime(Time)` could return nullptr when creating a new `AM_Als_Mantle_High` for a different character.

![filled enough](https://github.com/Sixze/ALS-Refactored/assets/250165/37b428de-d433-4478-92b8-331481ea9a9b)
Even though it appears on the editor that the animation sequence exists up to the end of the montage, it seems that `AnimTrack.GetSegmentAtTime(Montage->GetPlayLength())` can return nullptr.

This pull request avoids this issue.

In addition to `ExtractRootTransformFromMontage`, a new function `ExtractLastRootTransformFromMontage` has been established to return the last value of RootTransform in the montage, and it has been modified to use this function.