### PR TITLE
Fix character overlay spine rotation when moving diagonally

### DIFF
--- a/Source/ALS/Private/AlsAnimationInstance.cpp
+++ b/Source/ALS/Private/AlsAnimationInstance.cpp
@@ -303,7 +303,7 @@ void UAlsAnimationInstance::RefreshViewOnGameThread()
 
 bool UAlsAnimationInstance::IsSpineRotationAllowed()
 {
-	return RotationMode == AlsRotationModeTags::Aiming;
+	return RotationMode != AlsRotationModeTags::VelocityDirection;
 }
 
 void UAlsAnimationInstance::RefreshView(const float DeltaTime)


### PR DESCRIPTION
Before:
![before](https://github.com/Sixze/ALS-Refactored/assets/4257207/f816082f-4adb-455f-8bc3-0df00d65615f)
After:
![after](https://github.com/Sixze/ALS-Refactored/assets/4257207/978ce086-ffd9-46ce-a933-0bf8896b9a7d)

The character's spine only allows rotation while aiming, so transitioning from the `Aiming` to `ViewDirection` rotation mode causes the spine to snap back to a non-rotated state instead of blending with the rest of the animation transition. This is especially apparent when moving at 45 degree angles, as the spine snaps to the pelvis's yaw rotation offset independent of the blend between the two animation states.

By allowing the spine to rotate in any rotation mode besides `VelocityDirection`, we produce more natural looking transitions after aiming, while maintaining the function of the spine rotating to match the pelvis.

This also allows the user more control over the spine's rotation through the `ViewBlock` and `AllowAiming` animation curves because of their new use in `UAlsAnimationInstance::RefreshSpineRotation()` when the character is not aiming. For example, if the user wants the spine to not rotate back to the pelvis's yaw rotation during an overlay pose, they can set `AllowAiming` to 1 for the duration of that overlay's pose.
![image](https://github.com/Sixze/ALS-Refactored/assets/4257207/94ceeeea-f1a0-4657-95ea-4cf8b0c5e325)