### PR TITLE
Check GroundedAmount with UE_SMALL_NUMBER make it safe not divided by zero

### DIFF
--- a/Source/ALS/Private/AlsAnimationInstance.cpp
+++ b/Source/ALS/Private/AlsAnimationInstance.cpp
@@ -282,7 +282,7 @@ void UAlsAnimationInstance::RefreshPose()
 	// Use the grounded pose curve value to "unweight" the gait pose curve. This is used to
 	// instantly get the full gait value from the very beginning of transitions to grounded states.
 
-	PoseState.UnweightedGaitAmount = PoseState.GroundedAmount > 0.0f
+	PoseState.UnweightedGaitAmount = PoseState.GroundedAmount > UE_SMALL_NUMBER
 		                                 ? PoseState.GaitAmount / PoseState.GroundedAmount
 		                                 : PoseState.GaitAmount;
 


### PR DESCRIPTION
The PoseState.GroundedAmount will used as a denominator. Check with UE_SMALL_NUMBER is better than 0 directly.