### PR TITLE
Example Update: Make input functions virtual

### DIFF
--- a/Source/ALS/Public/AlsAnimationInstance.h
+++ b/Source/ALS/Public/AlsAnimationInstance.h
@@ -175,14 +175,15 @@ private:
 
 	// View
 
-public:
-	virtual bool IsSpineRotationAllowed();
-
 private:
 	void RefreshViewOnGameThread();
 
 	void RefreshView(float DeltaTime);
 
+public:
+	virtual bool IsSpineRotationAllowed();
+
+private:
 	void RefreshSpine(float SpineBlendAmount, float DeltaTime);
 
 protected:
@@ -194,12 +195,12 @@ protected:
 
 	// Locomotion
 
+private:
+	void RefreshLocomotionOnGameThread();
+
 protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void InitializeLean();
-
-private:
-	void RefreshLocomotionOnGameThread();
 
 	// Grounded
 
@@ -208,20 +209,37 @@ public:
 
 protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
+	void ResetGroundedEntryMode();
+
+protected:
+	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void InitializeGrounded();
 
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void RefreshGrounded();
 
-	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
-	void ResetGroundedEntryMode();
+private:
+	FVector3f GetRelativeVelocity() const;
 
+	FVector2f GetRelativeAccelerationAmount() const;
+
+	void RefreshVelocityBlend();
+
+	void RefreshGroundedLean();
+
+protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void RefreshGroundedMovement();
 
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void SetHipsDirection(EAlsHipsDirection NewHipsDirection);
 
+private:
+	void RefreshMovementDirection(float ViewRelativeVelocityYawAngle);
+
+	void RefreshRotationYawOffsets(float ViewRelativeVelocityYawAngle);
+
+protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void InitializeStandingMovement();
 
@@ -237,30 +255,17 @@ protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void RefreshCrouchingMovement();
 
-private:
-	FVector2f GetRelativeAccelerationAmount() const;
-
-	FVector3f GetRelativeVelocity() const;
-
-	void RefreshVelocityBlend();
-
-	void RefreshMovementDirection(float ViewRelativeVelocityYawAngle);
-
-	void RefreshRotationYawOffsets(float ViewRelativeVelocityYawAngle);
-
-	void RefreshGroundedLean();
-
 	// In Air
 
 public:
 	void Jump();
 
+private:
+	void RefreshInAirOnGameThread();
+
 protected:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Animation Instance", Meta = (BlueprintProtected, BlueprintThreadSafe))
 	void RefreshInAir();
-
-private:
-	void RefreshInAirOnGameThread();
 
 	void RefreshGroundPrediction();
 

--- a/Source/ALSExtras/Public/AlsCharacterExample.h
+++ b/Source/ALSExtras/Public/AlsCharacterExample.h
@@ -89,31 +89,31 @@ protected:
 	virtual void SetupPlayerInputComponent(UInputComponent* Input) override;
 
 private:
-	void Input_OnLookMouse(const FInputActionValue& ActionValue);
+	virtual void Input_OnLookMouse(const FInputActionValue& ActionValue);
 
-	void Input_OnLook(const FInputActionValue& ActionValue);
+	virtual void Input_OnLook(const FInputActionValue& ActionValue);
 
-	void Input_OnMove(const FInputActionValue& ActionValue);
+	virtual void Input_OnMove(const FInputActionValue& ActionValue);
 
-	void Input_OnSprint(const FInputActionValue& ActionValue);
+	virtual void Input_OnSprint(const FInputActionValue& ActionValue);
 
-	void Input_OnWalk();
+	virtual void Input_OnWalk();
 
-	void Input_OnCrouch();
+	virtual void Input_OnCrouch();
 
-	void Input_OnJump(const FInputActionValue& ActionValue);
+	virtual void Input_OnJump(const FInputActionValue& ActionValue);
 
-	void Input_OnAim(const FInputActionValue& ActionValue);
+	virtual void Input_OnAim(const FInputActionValue& ActionValue);
 
-	void Input_OnRagdoll();
+	virtual void Input_OnRagdoll();
 
-	void Input_OnRoll();
+	virtual void Input_OnRoll();
 
-	void Input_OnRotationMode();
+	virtual void Input_OnRotationMode();
 
-	void Input_OnViewMode();
+	virtual void Input_OnViewMode();
 
-	void Input_OnSwitchShoulder();
+	virtual void Input_OnSwitchShoulder();
 
 	// Debug
 


### PR DESCRIPTION
## What
* Makes Example Character's `Input_*` functions virtual so they can be overridden by child classes

## Why
* The example character is a good place to start as a child for getting going. It is common to need to change things, as such these Input functions can be virtual so they can be overridden.