### PR TITLE
Fixed: correct uenum type constrain

### DIFF
--- a/Source/ALS/Public/Utility/AlsEnumUtility.h
+++ b/Source/ALS/Public/Utility/AlsEnumUtility.h
@@ -5,13 +5,16 @@
 
 namespace AlsEnumUtility
 {
-	template <typename EnumType> requires std::is_enum_v<EnumType>
+	template<class T>
+	concept is_uenum = static_cast<bool>(TIsUEnumClass<T>::Value);
+
+	template <is_uenum EnumType>
 	int32 GetIndexByValue(const EnumType Value)
 	{
 		return StaticEnum<EnumType>()->GetIndexByValue(static_cast<int64>(Value));
 	}
 
-	template <typename EnumType> requires std::is_enum_v<EnumType>
+	template <is_uenum EnumType>
 	FString GetNameStringByValue(const EnumType Value)
 	{
 		return StaticEnum<EnumType>()->GetNameStringByValue(static_cast<int64>(Value));


### PR DESCRIPTION
Fix: https://github.com/Sixze/ALS-Refactored/commit/e433ad2f3610c3c3249d0b381a54115addf3964c#commitcomment-162850074

<details>
<summary>
MSVC
</summary>

> Using Visual Studio 2022 14.44.35211 toolchain (D:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207) and Windows 10.0.26100.0 SDK (C:\Program Files (x86)\Windows Kits\10).


</details>