### PR TITLE
feat: make auto in-air mantling optional

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -300,7 +300,7 @@ void AAlsCharacter::Tick(const float DeltaTime)
 	RefreshGroundedRotation(DeltaTime);
 	RefreshInAirRotation(DeltaTime);
 
-	StartMantlingInAir();
+	if (Settings->Mantling.bAutoInAirMantling) StartMantlingInAir();
 	RefreshMantling();
 	RefreshRagdolling(DeltaTime);
 	RefreshRolling(DeltaTime);

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -502,9 +502,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "ALS|Character", Meta = (ReturnDisplayName = "Success"))
 	bool StartMantlingGrounded();
 
-private:
+	UFUNCTION(BlueprintCallable, Category = "ALS|Character", Meta = (ReturnDisplayName = "Success"))
 	bool StartMantlingInAir();
 
+private:
 	bool StartMantling(const FAlsMantlingTraceSettings& TraceSettings);
 
 	UFUNCTION(Server, Reliable)

--- a/Source/ALS/Public/Settings/AlsMantlingSettings.h
+++ b/Source/ALS/Public/Settings/AlsMantlingSettings.h
@@ -106,6 +106,10 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS")
 	uint8 bAllowMantling : 1 {true};
 
+	// If true, the character will automatically try to mantle while in air.
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS")
+	uint8 bAutoInAirMantling: 1 {true};
+
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "ALS", Meta = (ClampMin = 0, ClampMax = 180, ForceUnits = "deg"))
 	float TraceAngleThreshold{110.0f};
 

--- a/Source/ALSExtras/Private/AlsCharacterExample.cpp
+++ b/Source/ALSExtras/Private/AlsCharacterExample.cpp
@@ -5,6 +5,7 @@
 #include "EnhancedInputSubsystems.h"
 #include "Engine/LocalPlayer.h"
 #include "GameFramework/PlayerController.h"
+#include "Settings/AlsCharacterSettings.h"
 #include "Utility/AlsVector.h"
 
 #include UE_INLINE_GENERATED_CPP_BY_NAME(AlsCharacterExample)
@@ -158,6 +159,11 @@ void AAlsCharacterExample::Input_OnJump(const FInputActionValue& ActionValue)
 	if (ActionValue.Get<bool>())
 	{
 		if (StopRagdolling())
+		{
+			return;
+		}
+
+		if (!Settings->Mantling.bAutoInAirMantling && LocomotionMode == AlsLocomotionModeTags::InAir && StartMantlingInAir())
 		{
 			return;
 		}


### PR DESCRIPTION
The default is preserved for backwards compatibility (true by default). When disabled, then player/ai input is required in order to trigger mantling while in air, just as it is while on the ground.

The example has also been updated to detect the state of this setting. If disabled, and the character is in air, then will attempt to perform in-air mantling as part of the OnJump input handler.

### NOTE TO REVIEWERS
- All permutations of this setting have been tested.
- Backward compatibility is preserved.