### PR TITLE
feat: use event delegate to indicate mantling completion

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -567,6 +567,7 @@ void AAlsCharacter::NotifyLocomotionModeChanged(const FGameplayTag& PreviousLoco
 		StartRagdolling();
 	}
 
+	OnLocomotionModeChangedEvent.Broadcast(PreviousLocomotionMode);
 	OnLocomotionModeChanged(PreviousLocomotionMode);
 }
 

--- a/Source/ALS/Private/AlsCharacter_Actions.cpp
+++ b/Source/ALS/Private/AlsCharacter_Actions.cpp
@@ -689,6 +689,7 @@ void AAlsCharacter::StopMantling(const bool bStopMontage)
 	AlsCharacterMovement->SetMovementModeLocked(false);
 	GetCharacterMovement()->SetMovementMode(MOVE_Walking);
 
+	OnMantlingComplete.Broadcast();
 	OnMantlingEnded();
 
 	ForceNetUpdate();

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -18,8 +18,10 @@ class UAlsMovementSettings;
 class UAlsAnimationInstance;
 class UAlsMantlingSettings;
 
-/// A general purpose delegate signature indicating the completion of some event.
+// A general purpose delegate signature indicating the completion of some event.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FEventComplete);
+// A delegate signature used for character locomotion mode changes.
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FLocomotionModeChanged, const FGameplayTag&, PreviousLocomotionMode);
 
 UCLASS(AutoExpandCategories = ("Settings|Als Character", "Settings|Als Character|Desired State"))
 class ALS_API AAlsCharacter : public ACharacter
@@ -176,9 +178,12 @@ private:
 	// Locomotion Mode
 
 public:
+	// Event emitted when the character's locomotion mode has changed.
+	UPROPERTY(BlueprintAssignable, Category = "ALS Character")
+	FLocomotionModeChanged OnLocomotionModeChangedEvent;
+
 	virtual void OnMovementModeChanged(EMovementMode PreviousMovementMode, uint8 PreviousCustomMode = 0) override;
 
-public:
 	const FGameplayTag& GetLocomotionMode() const;
 
 protected:
@@ -499,7 +504,7 @@ private:
 	// Mantling
 
 public:
-	/// Event emitted when a mantling action completes.
+	// Event emitted when a mantling action completes.
 	UPROPERTY(BlueprintAssignable, Category = "ALS Character")
 	FEventComplete OnMantlingComplete;
 
@@ -537,8 +542,7 @@ private:
 	void StopMantling(bool bStopMontage = false);
 
 protected:
-	// Deprecated: use \c OnMantlingComplete event delegate instead.
-	UFUNCTION(BlueprintNativeEvent, Category = "Als Character", meta = (DeprecatedFunction = "Deprecated: use OnMantlingComplete event delegate instead."))
+	UFUNCTION(BlueprintNativeEvent, Category = "Als Character")
 	void OnMantlingEnded();
 
 	// Ragdolling

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -18,6 +18,9 @@ class UAlsMovementSettings;
 class UAlsAnimationInstance;
 class UAlsMantlingSettings;
 
+/// A general purpose delegate signature indicating the completion of some event.
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FEventComplete);
+
 UCLASS(AutoExpandCategories = ("Settings|Als Character", "Settings|Als Character|Desired State"))
 class ALS_API AAlsCharacter : public ACharacter
 {
@@ -496,6 +499,10 @@ private:
 	// Mantling
 
 public:
+	/// Event emitted when a mantling action completes.
+	UPROPERTY(BlueprintAssignable, Category = "ALS Character")
+	FEventComplete OnMantlingComplete;
+
 	UFUNCTION(BlueprintNativeEvent, Category = "Als Character")
 	bool IsMantlingAllowedToStart() const;
 
@@ -530,7 +537,8 @@ private:
 	void StopMantling(bool bStopMontage = false);
 
 protected:
-	UFUNCTION(BlueprintNativeEvent, Category = "Als Character")
+	// Deprecated: use \c OnMantlingComplete event delegate instead.
+	UFUNCTION(BlueprintNativeEvent, Category = "Als Character", meta = (DeprecatedFunction = "Deprecated: use OnMantlingComplete event delegate instead."))
 	void OnMantlingEnded();
 
 	// Ragdolling


### PR DESCRIPTION
This model allows for more seamless integration regardless of location (C++ or BP).

The BlueprintNativeEvent OnMantlingEnded is still in place and being called as it has been; however, it is now deprecated in favor of the event.