### PR TITLE
Fix crash in StopRagdollingImplementation when mesh transforms are uninitialized

### DIFF
--- a/Source/ALS/Private/AlsCharacter_Actions.cpp
+++ b/Source/ALS/Private/AlsCharacter_Actions.cpp
@@ -1066,6 +1066,11 @@ void AAlsCharacter::StopRagdollingImplementation()
 		return;
 	}
 
+	if (!AnimationInstance.IsValid() || GetMesh()->GetComponentSpaceTransforms().IsEmpty())
+	{
+		return;
+	}
+
 	auto& FinalRagdollPose{AnimationInstance->SnapshotFinalRagdollPose()};
 
 	const auto PelvisTransform{GetMesh()->GetSocketTransform(UAlsConstants::PelvisBoneName())};


### PR DESCRIPTION
  ## Problem

  `StopRagdollingImplementation` crashes with an access violation (reading address `0x0`) inside `USkeletalMeshComponent::SnapshotPose`, called via `SnapshotFinalRagdollPose`.

  The engine's `SnapshotPose` accesses `ComponentSpaceTMs[0]` unconditionally. When the array is empty its internal `Data` pointer is null, causing the null read.

  Stack trace:
  UAlsAnimationInstance::SnapshotFinalRagdollPose() [AlsAnimationInstance.cpp:2071]
  AAlsCharacter::StopRagdollingImplementation() [AlsCharacter_Actions.cpp:1069]

  ## Root cause

  Two conditions can leave `StopRagdollingImplementation` in a state where `SnapshotPose` is unsafe to call:

  1. **`AnimationInstance` is null** — this was the only call site in `AlsCharacter_Actions.cpp` that used `AnimationInstance` without an `IsValid()` check, inconsistent with every call site in `AlsCharacter.cpp`.

  2. **`GetComponentSpaceTransforms()` is empty** — occurs when `StopRagdolling` is called on a character whose mesh has not yet completed its first animation evaluation (e.g. first tick after a dynamic spawn), but whose
  `LocomotionAction` is already `Ragdolling` (e.g. restored from save state or set before the mesh ticked).

  ## Fix

  Add a guard before the snapshot call. If either condition holds, return early — the character stays in ragdoll state and the next call to `StopRagdolling` will complete normally once the mesh is initialized.
