### PR TITLE
Access level updates & validation

### DIFF
--- a/Source/ALS/Public/Notifies/AlsAnimNotify_FootstepEffects.h
+++ b/Source/ALS/Public/Notifies/AlsAnimNotify_FootstepEffects.h
@@ -244,7 +244,7 @@ public:
 	virtual void Notify(USkeletalMeshComponent* Mesh, UAnimSequenceBase* Sequence,
 	                    const FAnimNotifyEventReference& NotifyEventReference) override;
 
-private:
+protected:
 	void SpawnSound(USkeletalMeshComponent* Mesh, const FAlsFootstepSoundSettings& SoundSettings,
 	                const FVector& FootstepLocation, const FQuat& FootstepRotation) const;
 

--- a/Source/ALSCamera/Private/AlsCameraComponent.cpp
+++ b/Source/ALSCamera/Private/AlsCameraComponent.cpp
@@ -6,6 +6,7 @@
 #include "Engine/OverlapResult.h"
 #include "GameFramework/Character.h"
 #include "GameFramework/WorldSettings.h"
+#include "Misc/DataValidation.h"
 #include "Utility/AlsCameraConstants.h"
 #include "Utility/AlsDebugUtility.h"
 #include "Utility/AlsMacros.h"
@@ -22,6 +23,20 @@ UAlsCameraComponent::UAlsCameraComponent()
 	bTickInEditor = false;
 	bHiddenInGame = true;
 }
+
+#if WITH_EDITOR
+EDataValidationResult UAlsCameraComponent::IsDataValid(class FDataValidationContext& Context) const {
+	auto Res = Super::IsDataValid(Context);
+
+	// Ensure camera settings are in place.
+	if (!IsValid(Settings)) {
+		Context.AddError(INVTEXT("Camera.Settings must be set"));
+		Res = EDataValidationResult::Invalid;
+	}
+
+	return Res;
+}
+#endif
 
 void UAlsCameraComponent::PostLoad()
 {

--- a/Source/ALSCamera/Public/AlsCameraComponent.h
+++ b/Source/ALSCamera/Public/AlsCameraComponent.h
@@ -78,6 +78,10 @@ protected:
 public:
 	UAlsCameraComponent();
 
+	#if WITH_EDITOR
+	virtual EDataValidationResult IsDataValid(class FDataValidationContext& Context) const override;
+	#endif
+
 	virtual void PostLoad() override;
 
 	virtual void OnRegister() override;


### PR DESCRIPTION
Make AlsAnimNotify_FootstepEffects more meaningfully extendable by exposing a few of its core methods as protected instead of private.

Add validation to the AlsCameraComponent to avoid trivial, but sometimes hard to track down, missing settings.

TBH, there are lots of locations where it would be beneficial to add some data validation, but maybe this is a sufficient start.