### PR TITLE
Expose virtual RefreshRotation to make extensions more viable w/ other locomotion modes

### DIFF
--- a/Source/ALS/Private/AlsCharacter.cpp
+++ b/Source/ALS/Private/AlsCharacter.cpp
@@ -287,8 +287,7 @@ void AAlsCharacter::Tick(const float DeltaTime)
 	RefreshGait();
 	RefreshRotationMode();
 
-	RefreshGroundedRotation(DeltaTime);
-	RefreshInAirRotation(DeltaTime);
+	RefreshRotation(DeltaTime);
 
 	AutoStartMantling();
 	RefreshMantling();
@@ -1660,6 +1659,12 @@ void AAlsCharacter::RefreshGroundedRotation(const float DeltaTime)
 	}
 
 	RefreshTargetYawAngleUsingActorRotation();
+}
+
+void AAlsCharacter::RefreshRotation(const float DeltaTime)
+{
+	RefreshGroundedRotation(DeltaTime);
+	RefreshInAirRotation(DeltaTime);
 }
 
 bool AAlsCharacter::RefreshCustomGroundedMovingRotation(const float DeltaTime)

--- a/Source/ALS/Public/AlsCharacter.h
+++ b/Source/ALS/Public/AlsCharacter.h
@@ -431,6 +431,13 @@ private:
 	void RefreshGroundedRotation(float DeltaTime);
 
 protected:
+	/// Refresh rotation according to the current locomotion mode.
+	///
+	/// Overrides should typically call super, as it already encapsulates and handles Grounded & InAir rotation.
+	/// Subclasses which implement support for other locomotion modes, such as flying or swimming, can override
+	/// this method to implement rotation refresh for such locomotion modes.
+	virtual void RefreshRotation(float DeltaTime);
+
 	virtual bool RefreshCustomGroundedMovingRotation(float DeltaTime);
 
 	virtual bool RefreshCustomGroundedNotMovingRotation(float DeltaTime);


### PR DESCRIPTION
As it stands, it is quite difficult to extend some of the core bits without directly modifying AlsCharacter directly. That is less than optimal. This method makes RefreshRotation a protected virtual extension point so that implementing other locomotion modes not covered by this system, and which do not fall into the Grounded or InAir (falling/jumping) categories.